### PR TITLE
🔧 Remove "major" version restriction for typing-extensions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -338,7 +338,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "90501e9538b0e00bb0ae7a0b27f332cfbd4a2816bcd7726030d920a362e8f67d"
+content-hash = "d2c7d3aea4bd9fc46799ab96ae75a94b507d304d88e39ff18bbf9d3bfda60d31"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-typing-extensions = "^3.7.4"
+typing-extensions = ">= 3.7.4, < 5.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.812"


### PR DESCRIPTION
`typing-extensions` v4 has been released, this lib is creating version conflicts by locking the "version" of the extensions library. This changes the specifier from `^3.7.4` to `>=3.7.4`, to allow for v4 to be installed with other type libs that require the latest version of `typing-extensions`.